### PR TITLE
Removing default title text again. It got merged out somehow.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: File a bug report
-title: " "
+title: "The bug report title"
 labels: [bug, untriaged]
 body:
 - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: File a bug report
-title: "[Bug]: "
-labels: [bug, triage]
+title: " "
+labels: [bug, untriaged]
 body:
 - type: markdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/feature_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/feature_enhancement.yml
@@ -1,6 +1,6 @@
 name: Feature Enhancement
 description: Suggest an idea for this project
-title: " "
+title: "The feature enhancement title"
 labels: [enhancement, untriaged]
 body:
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/feature_enhancement.yml
@@ -1,7 +1,7 @@
 name: Feature Enhancement
 description: Suggest an idea for this project
-title: "[Feature]: *Use a clear and descriptive title for the issue to identify the suggestion.*"
-labels: [enhancement]
+title: " "
+labels: [enhancement, untriaged]
 body:
 - type: textarea
   id: description


### PR DESCRIPTION
Complete the following tasks before merging in your PR:
- [x] If this is a user facing change, update [version.txt](https://github.com/relativitydev/relativity.testing.framework/blob/master/version.txt) and [CHANGELOG.md](https://github.com/relativitydev/relativity.testing.framework/blob/master/CHANGELOG.md)