### PR TITLE
DEVOPS-182835: Use correct version of DocFx in release build

### DIFF
--- a/.github/workflows/ReleaseBranch.yaml
+++ b/.github/workflows/ReleaseBranch.yaml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Build Documentation
       run: |
-        Invoke-WebRequest https://github.com/dotnet/docfx/releases/download/v2.58/docfx.zip -OutFile docfx.zip
+        Invoke-WebRequest https://github.com/dotnet/docfx/releases/download/v2.59.4/docfx.zip -OutFile docfx.zip
         Expand-Archive -Path .\docfx.zip -DestinationPath DocFx
         DocFx/docfx.exe source/Relativity.Testing.Framework.Documentation/docfx.json
 


### PR DESCRIPTION
Complete the following tasks before merging in your PR:
- [x] If this is a user facing change, update [version.txt](https://github.com/relativitydev/relativity.testing.framework/blob/master/version.txt) and [CHANGELOG.md](https://github.com/relativitydev/relativity.testing.framework/blob/master/CHANGELOG.md)